### PR TITLE
Update ServiceProvider for Laravel 5.2

### DIFF
--- a/src/UserPrivilegeMapper.php
+++ b/src/UserPrivilegeMapper.php
@@ -15,27 +15,12 @@ class UserPrivilegeMapper
 {
     use Macroable;
 
-    /**
-     * UserPrivilegeMapper constructor.
-     *
-     * @param $app
-     */
-    public
-    function __construct($app)
+    public static function __callStatic($method, $parameters)
     {
-    }
-
-    public static
-    function __callStatic($method, $parameters)
-    {
-        if (static::hasMacro($method))
-        {
-            if (static::$macros[$method] instanceof Closure)
-            {
+        if (static::hasMacro($method)) {
+            if (static::$macros[$method] instanceof Closure) {
                 return call_user_func_array(Closure::bind(static::$macros[$method], null, get_called_class()), $parameters);
-            }
-            else
-            {
+            } else {
                 return call_user_func_array(static::$macros[$method], $parameters);
             }
         }
@@ -43,17 +28,12 @@ class UserPrivilegeMapper
         return false;
     }
 
-    public
-    function __call($method, $parameters)
+    public function __call($method, $parameters)
     {
-        if (static::hasMacro($method))
-        {
-            if (static::$macros[$method] instanceof Closure)
-            {
+        if (static::hasMacro($method)) {
+            if (static::$macros[$method] instanceof Closure) {
                 return call_user_func_array(static::$macros[$method]->bindTo($this, get_class($this)), $parameters);
-            }
-            else
-            {
+            } else {
                 return call_user_func_array(static::$macros[$method], $parameters);
             }
         }

--- a/src/UserPrivilegeMapperServiceProvider.php
+++ b/src/UserPrivilegeMapperServiceProvider.php
@@ -1,4 +1,6 @@
-<?php namespace Vsch\UserPrivilegeMapper;
+<?php
+
+namespace Vsch\UserPrivilegeMapper;
 
 use Illuminate\Support\ServiceProvider;
 
@@ -23,9 +25,8 @@ class UserPrivilegeMapperServiceProvider extends ServiceProvider {
 	 */
 	protected function registerUserPrivilegeMapper()
 	{
-		$this->app->bindShared('privilege', function($app)
-		{
-			return new UserPrivilegeMapper($app);
+		$this->app->singleton('privilege', function () {
+			return $this->app->make('Vsch\UserPrivilegeMapper\UserPrivilegeMapper');
 		});
 	}
 


### PR DESCRIPTION
The service container's bindShared method has been deprecated in favor of the singleton method.

ref: https://laravel.com/docs/5.2/upgrade#upgrade-5.1.11
